### PR TITLE
Restore selectable text and keep bubble width

### DIFF
--- a/MiMoApp/Services/LMStudioClient.swift
+++ b/MiMoApp/Services/LMStudioClient.swift
@@ -17,6 +17,7 @@ class LMStudioClient {
         prompt: String,
         host: String,
         port: String,
+        systemPrompt: String,
         onUpdate: @escaping (String) -> Void,
         onFinish: @escaping () -> Void
     ) -> Task<Void, Never> {
@@ -29,12 +30,16 @@ class LMStudioClient {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        var messages: [[String: String]] = []
+        if !systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            messages.append(["role": "system", "content": systemPrompt])
+        }
+        messages.append(["role": "user", "content": prompt])
+
         let body: [String: Any] = [
             "model": model,
             "stream": true,
-            "messages": [
-                ["role": "user", "content": prompt]
-            ]
+            "messages": messages
         ]
 
         do {

--- a/MiMoApp/ViewModels/ConversationsViewModel.swift
+++ b/MiMoApp/ViewModels/ConversationsViewModel.swift
@@ -12,17 +12,20 @@ import SwiftUI
 struct Conversation: Identifiable, Equatable {
     let id: UUID
     var name: String
+    var systemPrompt: String
     var messages: [ChatMessage]
 
-    init(name: String, messages: [ChatMessage] = []) {
+    init(name: String, systemPrompt: String = "", messages: [ChatMessage] = []) {
         self.id = UUID()
         self.name = name
+        self.systemPrompt = systemPrompt
         self.messages = messages
     }
 
     static func == (lhs: Conversation, rhs: Conversation) -> Bool {
         lhs.id == rhs.id &&
         lhs.name == rhs.name &&
+        lhs.systemPrompt == rhs.systemPrompt &&
         lhs.messages == rhs.messages
     }
 }

--- a/MiMoApp/ViewModels/ServerConfigViewModel.swift
+++ b/MiMoApp/ViewModels/ServerConfigViewModel.swift
@@ -8,7 +8,7 @@ class ServerConfigViewModel: ObservableObject {
     @Published var address = UserDefaults.standard.string(forKey: "lmHost") ?? ""
     @Published var port = UserDefaults.standard.string(forKey: "lmPort") ?? ""
     @Published var supportsImageInput: Bool = false
-    @Published var appVersion: String = "0.0.1"
+    @Published var appVersion: String = "0.0.3"
 
     // MARK: — Modelos
     @Published var models = UserDefaults.standard.stringArray(forKey: "lmModels") ?? []

--- a/MiMoApp/ViewModels/ServerConfigViewModel.swift
+++ b/MiMoApp/ViewModels/ServerConfigViewModel.swift
@@ -8,6 +8,7 @@ class ServerConfigViewModel: ObservableObject {
     @Published var address = UserDefaults.standard.string(forKey: "lmHost") ?? ""
     @Published var port = UserDefaults.standard.string(forKey: "lmPort") ?? ""
     @Published var supportsImageInput: Bool = false
+    @Published var appVersion: String = "0.0.1"
 
     // MARK: — Modelos
     @Published var models = UserDefaults.standard.stringArray(forKey: "lmModels") ?? []

--- a/MiMoApp/ViewModels/ServerConfigViewModel.swift
+++ b/MiMoApp/ViewModels/ServerConfigViewModel.swift
@@ -8,7 +8,7 @@ class ServerConfigViewModel: ObservableObject {
     @Published var address = UserDefaults.standard.string(forKey: "lmHost") ?? ""
     @Published var port = UserDefaults.standard.string(forKey: "lmPort") ?? ""
     @Published var supportsImageInput: Bool = false
-    @Published var appVersion: String = "0.0.3"
+    @Published var appVersion: String = "0.0.4"
 
     // MARK: — Modelos
     @Published var models = UserDefaults.standard.stringArray(forKey: "lmModels") ?? []

--- a/MiMoApp/Views/ChatView.swift
+++ b/MiMoApp/Views/ChatView.swift
@@ -38,8 +38,9 @@ struct ChatView: View {
                         .stroke(
                             style: StrokeStyle(lineWidth: 1, dash: [4])
                         )
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color(uiColor: .systemGray4))
                 )
+                .padding(.horizontal)
                 .layoutPriority(1)
 
             // — 2) Indicador de “Escribiendo…” mientras llegue streaming
@@ -246,7 +247,6 @@ struct ChatMessagesView: View {
                         MessageBubble(message: msg)
                     }
                 }
-                .padding(.horizontal)
             }
             .onChange(of: messages.count) { _ in
                 if let last = messages.last?.id {
@@ -262,7 +262,7 @@ struct ChatMessagesView: View {
 struct MessageBubble: View {
     let message: ChatMessage
     private var maxBubbleWidth: CGFloat {
-        UIScreen.main.bounds.width * 0.75
+        UIScreen.main.bounds.width - 32
     }
     var body: some View {
         VStack(alignment: message.isUser ? .trailing : .leading,
@@ -299,7 +299,6 @@ struct MessageBubble: View {
                alignment: message.isUser ? .trailing : .leading)
         .padding(message.isUser ? .leading : .trailing, 50)
         .padding(.vertical, 4)
-        .padding(.horizontal)
     }
 }
 

--- a/MiMoApp/Views/ChatView.swift
+++ b/MiMoApp/Views/ChatView.swift
@@ -245,6 +245,9 @@ struct ChatMessagesView: View {
 
 struct MessageBubble: View {
     let message: ChatMessage
+    private var maxBubbleWidth: CGFloat {
+        UIScreen.main.bounds.width * 0.75
+    }
     var body: some View {
         VStack(alignment: message.isUser ? .trailing : .leading,
                spacing: 8) {
@@ -262,18 +265,20 @@ struct MessageBubble: View {
                 }
             }
             if let text = message.text, !text.isEmpty {
-                Text(text)
+                SelectableText(text: text,
+                               textColor: message.isUser ? .white : .black)
                     .padding(12)
-                    .foregroundColor(message.isUser ? .white : .black)
                     .background(
                         message.isUser ? Color.blue : Color.white
                     )
                     .cornerRadius(16)
-                    .frame(maxWidth: 300,
+                    .frame(maxWidth: .infinity,
                            alignment: message.isUser ? .trailing : .leading)
                     .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
             }
         }
+        .frame(maxWidth: maxBubbleWidth,
+               alignment: message.isUser ? .trailing : .leading)
         .frame(maxWidth: .infinity,
                alignment: message.isUser ? .trailing : .leading)
         .padding(message.isUser ? .leading : .trailing, 50)
@@ -281,4 +286,5 @@ struct MessageBubble: View {
         .padding(.horizontal)
     }
 }
+
 

--- a/MiMoApp/Views/ChatView.swift
+++ b/MiMoApp/Views/ChatView.swift
@@ -7,6 +7,8 @@ import UIKit
 struct ChatView: View {
     // 1) Binding de mensajes
     @Binding var messages: [ChatMessage]
+    // System prompt por pestaña
+    @Binding var systemPrompt: String
     // 2) ChatViewModel
     @StateObject private var viewModel: ChatViewModel
     // 3) ConfigVM compartido
@@ -15,13 +17,19 @@ struct ChatView: View {
     // Control para presentar el picker
     @State private var showingPhotoPicker = false
 
-    init(messages: Binding<[ChatMessage]>) {
-        _messages  = messages
-        _viewModel = StateObject(wrappedValue: ChatViewModel(bindingMessages: messages))
+    init(messages: Binding<[ChatMessage]>, systemPrompt: Binding<String>) {
+        _messages     = messages
+        _systemPrompt = systemPrompt
+        _viewModel    = StateObject(wrappedValue: ChatViewModel(bindingMessages: messages))
     }
 
     var body: some View {
         VStack(spacing: 0) {
+            TextField("System prompt…", text: $systemPrompt)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+                .padding(.top, 8)
+
             // — 1) Lista de mensajes, ocupa todo el espacio disponible
             ChatMessagesView(messages: messages)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -80,7 +88,8 @@ struct ChatView: View {
                     viewModel.sendPrompt(
                         model: configVM.selectedModel,
                         host:  configVM.address,
-                        port:  configVM.port
+                        port:  configVM.port,
+                        systemPrompt: systemPrompt
                     )
                 },
                 showImagePicker: {

--- a/MiMoApp/Views/ChatView.swift
+++ b/MiMoApp/Views/ChatView.swift
@@ -33,6 +33,13 @@ struct ChatView: View {
             // — 1) Lista de mensajes, ocupa todo el espacio disponible
             ChatMessagesView(messages: messages)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 0)
+                        .stroke(
+                            style: StrokeStyle(lineWidth: 1, dash: [4])
+                        )
+                        .foregroundColor(.secondary)
+                )
                 .layoutPriority(1)
 
             // — 2) Indicador de “Escribiendo…” mientras llegue streaming

--- a/MiMoApp/Views/ChatView.swift
+++ b/MiMoApp/Views/ChatView.swift
@@ -239,7 +239,7 @@ struct ChatMessagesView: View {
                         MessageBubble(message: msg)
                     }
                 }
-                .padding()
+                .padding(.horizontal)
             }
             .onChange(of: messages.count) { _ in
                 if let last = messages.last?.id {

--- a/MiMoApp/Views/MainView.swift
+++ b/MiMoApp/Views/MainView.swift
@@ -46,7 +46,8 @@ struct MainView: View {
                                 .cornerRadius(8)
                         }
                     }
-                    .padding(.horizontal)
+                    .padding(.leading)
+                    .padding(.trailing, 60)
                     .padding(.top, 10)
                 }
 

--- a/MiMoApp/Views/MainView.swift
+++ b/MiMoApp/Views/MainView.swift
@@ -9,43 +9,54 @@ struct MainView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // — Pestañas superiores
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(convVM.conversations.indices, id: \.self) { index in
-                        Button {
-                            convVM.currentConversationIndex = index
-                        } label: {
-                            Text(convVM.conversations[index].name)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(
-                                    index == convVM.currentConversationIndex
-                                        ? Color.gray
-                                        : Color.secondary.opacity(0.2)
-                                )
-                                .foregroundColor(.white)
-                                .cornerRadius(10)
-                        }
-                        .contextMenu {
-                            Button(role: .destructive) {
-                                convVM.deleteConversation(at: index)
+            // — Pestañas superiores con botón de configuración
+            ZStack(alignment: .topTrailing) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(convVM.conversations.indices, id: \.self) { index in
+                            Button {
+                                convVM.currentConversationIndex = index
                             } label: {
-                                Label("Eliminar conversación", systemImage: "trash")
+                                Text(convVM.conversations[index].name)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        index == convVM.currentConversationIndex
+                                            ? Color.gray
+                                            : Color.secondary.opacity(0.2)
+                                    )
+                                    .foregroundColor(.white)
+                                    .cornerRadius(10)
+                            }
+                            .contextMenu {
+                                Button(role: .destructive) {
+                                    convVM.deleteConversation(at: index)
+                                } label: {
+                                    Label("Eliminar conversación", systemImage: "trash")
+                                }
                             }
                         }
-                    }
 
-                    Button {
-                        convVM.addNewConversation()
-                    } label: {
-                        Image(systemName: "plus")
-                            .padding(8)
-                            .background(Color.secondary.opacity(0.3))
-                            .cornerRadius(8)
+                        Button {
+                            convVM.addNewConversation()
+                        } label: {
+                            Image(systemName: "plus")
+                                .padding(8)
+                                .background(Color.secondary.opacity(0.3))
+                                .cornerRadius(8)
+                        }
                     }
+                    .padding(.horizontal)
+                    .padding(.top, 10)
                 }
-                .padding(.horizontal)
+
+                Button {
+                    showingConfig.toggle()
+                } label: {
+                    Image(systemName: "gearshape")
+                        .padding(10)
+                }
+                .padding(.trailing)
                 .padding(.top, 10)
             }
 
@@ -58,22 +69,18 @@ struct MainView: View {
                     $convVM
                         .conversations[convVM.currentConversationIndex]
                         .messages
+                let systemPromptBinding =
+                    $convVM
+                        .conversations[convVM.currentConversationIndex]
+                        .systemPrompt
 
                 // 2) Forzamos remount de ChatView al cambiar de modelo O de pestaña
                 Group {
-                    ChatView(messages: messagesBinding)
+                    ChatView(messages: messagesBinding,
+                             systemPrompt: systemPromptBinding)
                 }
                 .id("\(configVM.selectedModel)-\(convVM.currentConversationIndex)")
                 .environmentObject(configVM)
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button {
-                            showingConfig.toggle()
-                        } label: {
-                            Image(systemName: "gearshape")
-                        }
-                    }
-                }
             }
             .navigationViewStyle(.stack)  // evita caching en iPad
         }

--- a/MiMoApp/Views/SelectableText.swift
+++ b/MiMoApp/Views/SelectableText.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct SelectableText: UIViewRepresentable {
+    let text: String
+    var textColor: UIColor? = nil
+
+    func makeUIView(context: Context) -> UITextView {
+        let tv = UITextView()
+        tv.isEditable = false
+        tv.isScrollEnabled = false
+        tv.backgroundColor = .clear
+        tv.font = UIFont.preferredFont(forTextStyle: .body)
+        tv.adjustsFontForContentSizeCategory = true
+        tv.textContainer.lineFragmentPadding = 0
+        tv.textContainerInset = .zero
+        tv.dataDetectorTypes = []
+        return tv
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+        uiView.textColor = textColor ?? UIColor.label
+    }
+}
+

--- a/MiMoApp/Views/ServerConfigView.swift
+++ b/MiMoApp/Views/ServerConfigView.swift
@@ -130,6 +130,7 @@ struct ServerConfigView: View {
                           : "xmark.octagon")
                     .foregroundColor(configVM.supportsImageInput ? .green : .red)
             }
+            Text("Versión: \(configVM.appVersion)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement a `SelectableText` UIViewRepresentable so message text can be copied partially
- use this view inside `MessageBubble` while keeping bubble width capped

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851d0607bb48331b1f6f88d11c90f6c