### PR TITLE
Add scheduled tasks management

### DIFF
--- a/MiMoApp/Models/ScheduledTask.swift
+++ b/MiMoApp/Models/ScheduledTask.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Representa una tarea programada por el usuario.
+struct ScheduledTask: Identifiable, Codable, Equatable {
+    let id: UUID
+    var name: String
+    /// Expresión cron o descripción de la programación
+    var schedule: String
+    /// Prompt o acción a ejecutar
+    var prompt: String
+
+    init(id: UUID = UUID(), name: String, schedule: String, prompt: String) {
+        self.id = id
+        self.name = name
+        self.schedule = schedule
+        self.prompt = prompt
+    }
+}

--- a/MiMoApp/Models/ScheduledTask.swift
+++ b/MiMoApp/Models/ScheduledTask.swift
@@ -4,15 +4,15 @@ import Foundation
 struct ScheduledTask: Identifiable, Codable, Equatable {
     let id: UUID
     var name: String
-    /// Expresión cron o descripción de la programación
-    var schedule: String
+    /// Fecha y hora de ejecución
+    var runDate: Date
     /// Prompt o acción a ejecutar
     var prompt: String
 
-    init(id: UUID = UUID(), name: String, schedule: String, prompt: String) {
+    init(id: UUID = UUID(), name: String, runDate: Date, prompt: String) {
         self.id = id
         self.name = name
-        self.schedule = schedule
+        self.runDate = runDate
         self.prompt = prompt
     }
 }

--- a/MiMoApp/Models/ScheduledTask.swift
+++ b/MiMoApp/Models/ScheduledTask.swift
@@ -8,11 +8,18 @@ struct ScheduledTask: Identifiable, Codable, Equatable {
     var runDate: Date
     /// Prompt o acción a ejecutar
     var prompt: String
+    /// Fecha de ejecución real (nulo si aún no se ejecuta)
+    var executedAt: Date? = nil
+    /// Registro de la respuesta obtenida
+    var responseLog: String? = nil
 
-    init(id: UUID = UUID(), name: String, runDate: Date, prompt: String) {
+    init(id: UUID = UUID(), name: String, runDate: Date, prompt: String,
+         executedAt: Date? = nil, responseLog: String? = nil) {
         self.id = id
         self.name = name
         self.runDate = runDate
         self.prompt = prompt
+        self.executedAt = executedAt
+        self.responseLog = responseLog
     }
 }

--- a/MiMoApp/Models/ScheduledTask.swift
+++ b/MiMoApp/Models/ScheduledTask.swift
@@ -8,17 +8,20 @@ struct ScheduledTask: Identifiable, Codable, Equatable {
     var runDate: Date
     /// Prompt o acción a ejecutar
     var prompt: String
+    /// Imágenes adjuntas codificadas en JPEG
+    var imageDatas: [Data] = []
     /// Fecha de ejecución real (nulo si aún no se ejecuta)
     var executedAt: Date? = nil
     /// Registro de la respuesta obtenida
     var responseLog: String? = nil
 
     init(id: UUID = UUID(), name: String, runDate: Date, prompt: String,
-         executedAt: Date? = nil, responseLog: String? = nil) {
+         imageDatas: [Data] = [], executedAt: Date? = nil, responseLog: String? = nil) {
         self.id = id
         self.name = name
         self.runDate = runDate
         self.prompt = prompt
+        self.imageDatas = imageDatas
         self.executedAt = executedAt
         self.responseLog = responseLog
     }

--- a/MiMoApp/ViewModels/ScheduledTasksViewModel.swift
+++ b/MiMoApp/ViewModels/ScheduledTasksViewModel.swift
@@ -5,10 +5,17 @@ import SwiftUI
 class ScheduledTasksViewModel: ObservableObject {
     @Published var tasks: [ScheduledTask] = []
 
+    private var timer: Timer?
+    private weak var configVM: ServerConfigViewModel?
+
     private let tasksKey = "scheduledTasks"
 
     init() {
         load()
+    }
+
+    deinit {
+        timer?.invalidate()
     }
 
     func addTask(name: String, date: Date, prompt: String) {
@@ -19,6 +26,36 @@ class ScheduledTasksViewModel: ObservableObject {
 
     func deleteTask(at offsets: IndexSet) {
         tasks.remove(atOffsets: offsets)
+        save()
+    }
+
+    // MARK: - Monitoring
+    func startMonitoring(config: ServerConfigViewModel) {
+        configVM = config
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { await self?.checkDueTasks() }
+        }
+    }
+
+    private func checkDueTasks() async {
+        guard let config = configVM else { return }
+        let now = Date()
+        let due = tasks.filter { $0.runDate <= now }
+        guard !due.isEmpty else { return }
+
+        for task in due {
+            if !task.prompt.isEmpty {
+                _ = await LMStudioClient.sendPromptOnce(
+                    to: config.selectedModel,
+                    prompt: task.prompt,
+                    host: config.address,
+                    port: config.port
+                )
+            }
+        }
+
+        tasks.removeAll { $0.runDate <= now }
         save()
     }
 

--- a/MiMoApp/ViewModels/ScheduledTasksViewModel.swift
+++ b/MiMoApp/ViewModels/ScheduledTasksViewModel.swift
@@ -11,8 +11,8 @@ class ScheduledTasksViewModel: ObservableObject {
         load()
     }
 
-    func addTask(name: String, schedule: String, prompt: String) {
-        let task = ScheduledTask(name: name, schedule: schedule, prompt: prompt)
+    func addTask(name: String, date: Date, prompt: String) {
+        let task = ScheduledTask(name: name, runDate: date, prompt: prompt)
         tasks.append(task)
         save()
     }

--- a/MiMoApp/ViewModels/ScheduledTasksViewModel.swift
+++ b/MiMoApp/ViewModels/ScheduledTasksViewModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class ScheduledTasksViewModel: ObservableObject {
+    @Published var tasks: [ScheduledTask] = []
+
+    private let tasksKey = "scheduledTasks"
+
+    init() {
+        load()
+    }
+
+    func addTask(name: String, schedule: String, prompt: String) {
+        let task = ScheduledTask(name: name, schedule: schedule, prompt: prompt)
+        tasks.append(task)
+        save()
+    }
+
+    func deleteTask(at offsets: IndexSet) {
+        tasks.remove(atOffsets: offsets)
+        save()
+    }
+
+    // MARK: - Persistence
+    private func load() {
+        guard
+            let data = UserDefaults.standard.data(forKey: tasksKey),
+            let saved = try? JSONDecoder().decode([ScheduledTask].self, from: data)
+        else { return }
+        tasks = saved
+    }
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(tasks) {
+            UserDefaults.standard.set(data, forKey: tasksKey)
+        }
+    }
+}

--- a/MiMoApp/Views/MainView.swift
+++ b/MiMoApp/Views/MainView.swift
@@ -94,6 +94,9 @@ struct MainView: View {
             ScheduledTasksView()
                 .environmentObject(tasksVM)
         }
+        .onAppear {
+            tasksVM.startMonitoring(config: configVM)
+        }
     }
 }
 

--- a/MiMoApp/Views/MainView.swift
+++ b/MiMoApp/Views/MainView.swift
@@ -74,6 +74,7 @@ struct MainView: View {
                         } label: {
                             Image(systemName: "gearshape")
                         }
+                        .disabled(tasksVM.hasPendingImageTask)
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {
@@ -89,10 +90,12 @@ struct MainView: View {
         .sheet(isPresented: $showingConfig) {
             ServerConfigView()
                 .environmentObject(configVM)
+                .environmentObject(tasksVM)
         }
         .sheet(isPresented: $showingTasks) {
             ScheduledTasksView()
                 .environmentObject(tasksVM)
+                .environmentObject(configVM)
         }
         .onAppear {
             tasksVM.startMonitoring(config: configVM)

--- a/MiMoApp/Views/MainView.swift
+++ b/MiMoApp/Views/MainView.swift
@@ -5,7 +5,9 @@ import PhotosUI
 struct MainView: View {
     @StateObject private var convVM   = ConversationsViewModel()
     @StateObject private var configVM = ServerConfigViewModel()
+    @StateObject private var tasksVM  = ScheduledTasksViewModel()
     @State private   var showingConfig = false
+    @State private   var showingTasks  = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -73,6 +75,13 @@ struct MainView: View {
                             Image(systemName: "gearshape")
                         }
                     }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            showingTasks.toggle()
+                        } label: {
+                            Image(systemName: "clock.arrow.circlepath")
+                        }
+                    }
                 }
             }
             .navigationViewStyle(.stack)  // evita caching en iPad
@@ -80,6 +89,10 @@ struct MainView: View {
         .sheet(isPresented: $showingConfig) {
             ServerConfigView()
                 .environmentObject(configVM)
+        }
+        .sheet(isPresented: $showingTasks) {
+            ScheduledTasksView()
+                .environmentObject(tasksVM)
         }
     }
 }

--- a/MiMoApp/Views/ScheduledTasksView.swift
+++ b/MiMoApp/Views/ScheduledTasksView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct ScheduledTasksView: View {
+    @EnvironmentObject private var tasksVM: ScheduledTasksViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var schedule = ""
+    @State private var prompt = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Nueva tarea")) {
+                    TextField("Nombre", text: $name)
+                    TextField("Cron", text: $schedule)
+                    TextField("Prompt", text: $prompt)
+                    Button("Agregar") {
+                        guard !name.isEmpty, !schedule.isEmpty else { return }
+                        tasksVM.addTask(name: name, schedule: schedule, prompt: prompt)
+                        name = ""
+                        schedule = ""
+                        prompt = ""
+                    }
+                }
+
+                Section(header: Text("Tareas programadas")) {
+                    if tasksVM.tasks.isEmpty {
+                        Text("No hay tareas")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(tasksVM.tasks) { task in
+                            VStack(alignment: .leading) {
+                                Text(task.name)
+                                Text(task.schedule)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                if !task.prompt.isEmpty {
+                                    Text(task.prompt)
+                                        .font(.caption)
+                                }
+                            }
+                        }
+                        .onDelete(perform: tasksVM.deleteTask)
+                    }
+                }
+            }
+            .navigationTitle("Tareas programadas")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cerrar") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct ScheduledTasksView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScheduledTasksView()
+            .environmentObject(ScheduledTasksViewModel())
+    }
+}

--- a/MiMoApp/Views/ScheduledTasksView.swift
+++ b/MiMoApp/Views/ScheduledTasksView.swift
@@ -30,14 +30,28 @@ struct ScheduledTasksView: View {
                             .foregroundColor(.secondary)
                     } else {
                         ForEach(tasksVM.tasks) { task in
-                            VStack(alignment: .leading) {
-                                Text(task.name)
-                                Text(task.runDate.formatted(date: .abbreviated, time: .shortened))
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                if !task.prompt.isEmpty {
-                                    Text(task.prompt)
+                            HStack(alignment: .top) {
+                                VStack(alignment: .leading) {
+                                    Text(task.name)
+                                    Text(task.runDate.formatted(date: .abbreviated, time: .shortened))
                                         .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    if !task.prompt.isEmpty {
+                                        Text(task.prompt)
+                                            .font(.caption)
+                                    }
+                                    if let log = task.responseLog {
+                                        Text(log)
+                                            .font(.caption2)
+                                            .foregroundColor(.green)
+                                    }
+                                }
+
+                                Spacer()
+
+                                if task.executedAt != nil {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(.green)
                                 }
                             }
                         }

--- a/MiMoApp/Views/ScheduledTasksView.swift
+++ b/MiMoApp/Views/ScheduledTasksView.swift
@@ -5,7 +5,7 @@ struct ScheduledTasksView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var name = ""
-    @State private var schedule = ""
+    @State private var runDate = Date()
     @State private var prompt = ""
 
     var body: some View {
@@ -13,13 +13,13 @@ struct ScheduledTasksView: View {
             Form {
                 Section(header: Text("Nueva tarea")) {
                     TextField("Nombre", text: $name)
-                    TextField("Cron", text: $schedule)
+                    DatePicker("Fecha y hora", selection: $runDate, displayedComponents: [.date, .hourAndMinute])
                     TextField("Prompt", text: $prompt)
                     Button("Agregar") {
-                        guard !name.isEmpty, !schedule.isEmpty else { return }
-                        tasksVM.addTask(name: name, schedule: schedule, prompt: prompt)
+                        guard !name.isEmpty else { return }
+                        tasksVM.addTask(name: name, date: runDate, prompt: prompt)
                         name = ""
-                        schedule = ""
+                        runDate = Date()
                         prompt = ""
                     }
                 }
@@ -32,7 +32,7 @@ struct ScheduledTasksView: View {
                         ForEach(tasksVM.tasks) { task in
                             VStack(alignment: .leading) {
                                 Text(task.name)
-                                Text(task.schedule)
+                                Text(task.runDate.formatted(date: .abbreviated, time: .shortened))
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                 if !task.prompt.isEmpty {

--- a/MiMoApp/Views/ScheduledTasksView.swift
+++ b/MiMoApp/Views/ScheduledTasksView.swift
@@ -1,13 +1,17 @@
 import SwiftUI
 import UIKit
+import PhotosUI
 
 struct ScheduledTasksView: View {
     @EnvironmentObject private var tasksVM: ScheduledTasksViewModel
+    @EnvironmentObject private var configVM: ServerConfigViewModel
     @Environment(\.dismiss) private var dismiss
 
     @State private var name = ""
     @State private var runDate = Date()
     @State private var prompt = ""
+    @State private var images: [UIImage] = []
+    @State private var showPicker = false
 
     var body: some View {
         NavigationView {
@@ -16,12 +20,41 @@ struct ScheduledTasksView: View {
                     TextField("Nombre", text: $name)
                     DatePicker("Fecha y hora", selection: $runDate, displayedComponents: [.date, .hourAndMinute])
                     TextField("Prompt", text: $prompt)
+                    if configVM.supportsImageInput {
+                        if !images.isEmpty {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack {
+                                    ForEach(images.indices, id: \.self) { i in
+                                        Image(uiImage: images[i])
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 60, height: 60)
+                                            .clipped()
+                                            .cornerRadius(8)
+                                            .overlay(
+                                                Button {
+                                                    images.remove(at: i)
+                                                } label: {
+                                                    Image(systemName: "xmark.circle.fill")
+                                                        .foregroundColor(.white)
+                                                }
+                                                .offset(x: 6, y: -6)
+                                                , alignment: .topTrailing
+                                            )
+                                    }
+                                }
+                            }
+                        }
+                        Button("Seleccionar imágenes") { showPicker = true }
+                    }
                     Button("Agregar") {
                         guard !name.isEmpty else { return }
-                        tasksVM.addTask(name: name, date: runDate, prompt: prompt)
+                        let data = images.compactMap { $0.jpegData(compressionQuality: 0.8) }
+                        tasksVM.addTask(name: name, date: runDate, prompt: prompt, images: data)
                         name = ""
                         runDate = Date()
                         prompt = ""
+                        images = []
                     }
                 }
 
@@ -37,6 +70,21 @@ struct ScheduledTasksView: View {
                                     Text(task.runDate.formatted(date: .abbreviated, time: .shortened))
                                         .font(.caption)
                                         .foregroundColor(.secondary)
+                                    if !task.imageDatas.isEmpty {
+                                        ScrollView(.horizontal, showsIndicators: false) {
+                                            HStack {
+                                                ForEach(task.imageDatas, id: \.self) { data in
+                                                    if let img = UIImage(data: data) {
+                                                        Image(uiImage: img)
+                                                            .resizable()
+                                                            .scaledToFit()
+                                                            .frame(width: 60, height: 60)
+                                                            .cornerRadius(8)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                     if !task.prompt.isEmpty {
                                         Text(task.prompt)
                                             .font(.caption)
@@ -74,6 +122,9 @@ struct ScheduledTasksView: View {
                     Button("Cerrar") { dismiss() }
                 }
             }
+            .sheet(isPresented: $showPicker) {
+                PhotoPicker(selectedImages: $images, selectionLimit: 0)
+            }
         }
     }
 }
@@ -82,5 +133,6 @@ struct ScheduledTasksView_Previews: PreviewProvider {
     static var previews: some View {
         ScheduledTasksView()
             .environmentObject(ScheduledTasksViewModel())
+            .environmentObject(ServerConfigViewModel())
     }
 }

--- a/MiMoApp/Views/ScheduledTasksView.swift
+++ b/MiMoApp/Views/ScheduledTasksView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct ScheduledTasksView: View {
     @EnvironmentObject private var tasksVM: ScheduledTasksViewModel
@@ -45,6 +46,13 @@ struct ScheduledTasksView: View {
                                             .font(.caption2)
                                             .foregroundColor(.green)
                                             .textSelection(.enabled)
+                                            .contextMenu {
+                                                Button {
+                                                    UIPasteboard.general.string = log
+                                                } label: {
+                                                    Label("Copiar", systemImage: "doc.on.doc")
+                                                }
+                                            }
                                     }
                                 }
 

--- a/MiMoApp/Views/ScheduledTasksView.swift
+++ b/MiMoApp/Views/ScheduledTasksView.swift
@@ -44,6 +44,7 @@ struct ScheduledTasksView: View {
                                         Text(log)
                                             .font(.caption2)
                                             .foregroundColor(.green)
+                                            .textSelection(.enabled)
                                     }
                                 }
 

--- a/MiMoApp/Views/ServerConfigView.swift
+++ b/MiMoApp/Views/ServerConfigView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ServerConfigView: View {
     // ① Usa el mismo VM que viene de MainView
     @EnvironmentObject private var configVM: ServerConfigViewModel
+    @EnvironmentObject private var tasksVM: ScheduledTasksViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showDeleteAlert = false
 
@@ -66,7 +67,10 @@ struct ServerConfigView: View {
     // MARK: – Modelos
     private var modelsSection: some View {
         Section(header: Text("Modelos encontrados")) {
-            if configVM.isLoading {
+            if tasksVM.hasPendingImageTask {
+                Text("No puedes cambiar de modelo hasta que finalicen las tareas con imágenes")
+                    .foregroundColor(.secondary)
+            } else if configVM.isLoading {
                 ProgressView("Cargando modelos…")
             } else if configVM.models.isEmpty {
                 Text("Pulsa 'Recuperar modelos'")
@@ -92,6 +96,7 @@ struct ServerConfigView: View {
                     }
                     .contentShape(Rectangle())
                     .onTapGesture {
+                        guard !tasksVM.hasPendingImageTask else { return }
                         configVM.selectedModel = model
                     }
                 }
@@ -100,7 +105,7 @@ struct ServerConfigView: View {
             Button("Recuperar modelos") {
                 Task { await configVM.fetchModels() }
             }
-            .disabled(configVM.isLoading)
+            .disabled(configVM.isLoading || tasksVM.hasPendingImageTask)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 - Recuperación de la lista de modelos disponibles desde el servidor.
 - Streaming de respuestas para una experiencia fluida.
 - Configuración persistente de dirección, puerto y modelo seleccionado.
-- Apartado para programar tareas automáticas.
+- Apartado para programar tareas automáticas mediante selección de fecha y hora.
 
 ## Requisitos
 
@@ -31,7 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
-5. Accede al apartado de **tareas programadas** para añadir acciones automáticas según tu cronograma.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
-5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución. Las tareas finalizadas mostrarán una palomita verde, podrás revisar el texto devuelto por el modelo y seleccionar dicho registro para copiarlo.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución. Las tareas finalizadas mostrarán una palomita verde y guardan el texto devuelto por el modelo. Dicha respuesta es seleccionable y también puedes copiarla desde su menú contextual.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 - Recuperación de la lista de modelos disponibles desde el servidor.
 - Streaming de respuestas para una experiencia fluida.
 - Configuración persistente de dirección, puerto y modelo seleccionado.
+- Apartado para programar tareas automáticas.
 
 ## Requisitos
 
@@ -30,6 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas según tu cronograma.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 - Recuperación de la lista de modelos disponibles desde el servidor.
 - Streaming de respuestas para una experiencia fluida.
 - Configuración persistente de dirección, puerto y modelo seleccionado.
-- Apartado para programar tareas automáticas mediante selección de fecha y hora. Las tareas se ejecutan de forma automática cuando llega su momento.
+- Apartado para programar tareas automáticas mediante selección de fecha y hora. Las tareas se ejecutan de forma automática, se marcan con una palomita verde al completarse y guardan el registro de la respuesta obtenida.
 
 ## Requisitos
 
@@ -31,7 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
-5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución; se enviarán al modelo cuando llegue la hora.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución. Las tareas finalizadas mostrarán una palomita verde y podrás revisar el texto devuelto por el modelo.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
-5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución. Las tareas finalizadas mostrarán una palomita verde y podrás revisar el texto devuelto por el modelo.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución. Las tareas finalizadas mostrarán una palomita verde, podrás revisar el texto devuelto por el modelo y seleccionar dicho registro para copiarlo.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 - Recuperación de la lista de modelos disponibles desde el servidor.
 - Streaming de respuestas para una experiencia fluida.
 - Configuración persistente de dirección, puerto y modelo seleccionado.
-- Apartado para programar tareas automáticas mediante selección de fecha y hora.
+- Apartado para programar tareas automáticas mediante selección de fecha y hora. Las tareas se ejecutan de forma automática cuando llega su momento.
 
 ## Requisitos
 
@@ -31,7 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
-5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución; se enviarán al modelo cuando llegue la hora.
 
 ## Pruebas
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 - Recuperación de la lista de modelos disponibles desde el servidor.
 - Streaming de respuestas para una experiencia fluida.
 - Configuración persistente de dirección, puerto y modelo seleccionado.
-- Apartado para programar tareas automáticas mediante selección de fecha y hora. Las tareas se ejecutan de forma automática, se marcan con una palomita verde al completarse y guardan el registro de la respuesta obtenida.
+- Apartado para programar tareas automáticas mediante selección de fecha y hora. Las tareas se ejecutan automáticamente, se marcan con una palomita verde al completarse y guardan el registro de la respuesta obtenida. Si la tarea incluye imágenes sólo podrá ejecutarse con el modelo actual y éste no se podrá cambiar hasta que finalice.
 
 ## Requisitos
 
@@ -31,7 +31,7 @@ MiMoApp es un cliente iOS basado en SwiftUI que permite interactuar con un servi
 2. Pulsa **Recuperar modelos** para obtener la lista disponible y elige uno de ellos.
 3. Vuelve a la pantalla principal y comienza a chatear. Si el modelo admite imágenes podrás seleccionarlas desde la cámara o la galería.
 4. Puedes crear nuevas conversaciones, cambiar de modelo en cualquier momento o detener la respuesta en curso.
-5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución. Las tareas finalizadas mostrarán una palomita verde y guardan el texto devuelto por el modelo. Dicha respuesta es seleccionable y también puedes copiarla desde su menú contextual.
+5. Accede al apartado de **tareas programadas** para añadir acciones automáticas eligiendo la fecha y hora de ejecución e incluso adjuntar imágenes si el modelo lo permite. Si alguna tarea incluye imágenes no podrás cambiar de modelo hasta que se complete. Las tareas finalizadas muestran una palomita verde y guardan el texto devuelto, el cual puedes seleccionar o copiar desde su menú contextual.
 
 ## Pruebas
 


### PR DESCRIPTION
## Summary
- implement `ScheduledTask` model and persistence
- implement `ScheduledTasksViewModel` and `ScheduledTasksView`
- update `MainView` to open the scheduled tasks screen
- document new feature in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856d7016d148331a0d0d569ae056b79