### PR TITLE
Add Swift Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "MiMoApp",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .executable(name: "MiMoApp", targets: ["MiMoApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-testing", from: "0.5.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "MiMoApp",
+            path: "MiMoApp",
+            resources: [
+                .process("Assets.xcassets")
+            ]
+        ),
+        .testTarget(
+            name: "MiMoAppTests",
+            dependencies: [
+                "MiMoApp",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "MiMoAppTests"
+        ),
+        .testTarget(
+            name: "MiMoAppUITests",
+            dependencies: ["MiMoApp"],
+            path: "MiMoAppUITests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add a `Package.swift` manifest for the MiMoApp executable
- declare unit and UI test targets with correct paths

## Testing
- `swift test -l` *(fails: unable to fetch swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_6851db8ececc833193952710be4c69eb